### PR TITLE
(fixup) Use Ws2 for ip address parsing on Windows

### DIFF
--- a/zipkin/CMakeLists.txt
+++ b/zipkin/CMakeLists.txt
@@ -9,9 +9,14 @@ set(ZIPKIN_SRCS src/zipkin_core_types.cc
                  src/zipkin_reporter_impl.cc
                  src/zipkin_http_transporter.cc)
 
+set(WIN32_LIBRARIES)
+if(WIN32)
+   list(APPEND WIN32_LIBRARIES wsock32.lib ws2_32.lib)
+endif()
+
 if (BUILD_SHARED_LIBS)               
   add_library(zipkin SHARED ${ZIPKIN_SRCS})
-  target_link_libraries(zipkin Threads::Threads ${CURL_LIBRARIES})
+  target_link_libraries(zipkin Threads::Threads ${CURL_LIBRARIES} ${WIN32_LIBRARIES})
   set_target_properties(zipkin PROPERTIES VERSION ${ZIPKIN_VERSION_STRING}
                                           SOVERSION ${ZIPKIN_VERSION_MAJOR})
   install(TARGETS zipkin 
@@ -21,7 +26,7 @@ endif()
 if (BUILD_STATIC_LIBS)
   add_library(zipkin-static STATIC ${ZIPKIN_SRCS})
   set_target_properties(zipkin-static PROPERTIES OUTPUT_NAME zipkin)
-  target_link_libraries(zipkin-static Threads::Threads ${CURL_LIBRARIES})
+  target_link_libraries(zipkin-static Threads::Threads ${CURL_LIBRARIES} ${WIN32_LIBRARIES})
   install(TARGETS zipkin-static
           ARCHIVE DESTINATION lib)
 endif()

--- a/zipkin/src/ip_address.cc
+++ b/zipkin/src/ip_address.cc
@@ -1,4 +1,8 @@
+#ifdef _MSC_VER
+#include <Ws2tcpip.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include <cstring>
 #include <string>
 #include <zipkin/ip_address.h>


### PR DESCRIPTION
#15 is incomplete, my version was building because of a manual modification in the VS project. To use `inet_pton`, one needs to link with `wsock32` and `ws2_32`.