### PR TITLE
Sampling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
       - checkout
       - run: ./ci/install_dependencies.sh
       - run: ./ci/do_ci.sh cmake.asan
+      - store_artifacts:
+          path: /build/Testing/Temporary/LastTest.log
+          destination: Test.log
   tsan:
     docker:
       - image: ubuntu:17.10
@@ -14,6 +17,9 @@ jobs:
       - checkout
       - run: ./ci/install_dependencies.sh
       - run: ./ci/do_ci.sh cmake.tsan
+      - store_artifacts:
+          path: /build/Testing/Temporary/LastTest.log
+          destination: Test.log
   bazel:
     docker:
       - image: ubuntu:17.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,9 @@ jobs:
       - image: ubuntu:17.10
     steps:
       - checkout
+      - run: mkdir -p /build
       - run: ./ci/install_dependencies.sh
-      - run: ./ci/do_ci.sh cmake.tsan
+      - run: BUILD_DIR=/build ./ci/do_ci.sh cmake.tsan
       - store_artifacts:
           path: /build/Testing/Temporary/LastTest.log
           destination: Test.log

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.app
 
 bazel-*
+
+.build/

--- a/zipkin/include/zipkin/span_context.h
+++ b/zipkin/include/zipkin/span_context.h
@@ -58,6 +58,8 @@ public:
       : trace_id_{trace_id}, id_{id}, parent_id_{parent_id}, flags_{flags},
         is_initialized_{true} {}
 
+  bool isSampled() const { return flags_ & zipkin::sampled_flag; }
+
   /**
    * @return the span id as an integer
    */

--- a/zipkin/include/zipkin/zipkin_core_types.h
+++ b/zipkin/include/zipkin/zipkin_core_types.h
@@ -569,7 +569,7 @@ private:
   std::string name_;
   uint64_t id_;
   Optional<TraceId> parent_id_;
-  bool sampled_;
+  bool sampled_{true};
   bool debug_;
   std::vector<Annotation> annotations_;
   std::vector<BinaryAnnotation> binary_annotations_;

--- a/zipkin/include/zipkin/zipkin_core_types.h
+++ b/zipkin/include/zipkin/zipkin_core_types.h
@@ -331,7 +331,7 @@ public:
   Span()
       : trace_id_(0), name_(), id_(0), debug_(false), monotonic_start_time_(0),
         tracer_(nullptr) {}
-  
+
   void setSampled(const bool val) { sampled_ = val; }
   bool isSampled() const { return sampled_; }
 

--- a/zipkin/include/zipkin/zipkin_core_types.h
+++ b/zipkin/include/zipkin/zipkin_core_types.h
@@ -331,6 +331,9 @@ public:
   Span()
       : trace_id_(0), name_(), id_(0), debug_(false), monotonic_start_time_(0),
         tracer_(nullptr) {}
+  
+  void setSampled(const bool val) { sampled_ = val; }
+  bool isSampled() const { return sampled_; }
 
   /**
    * Sets the span's trace id attribute.
@@ -566,6 +569,7 @@ private:
   std::string name_;
   uint64_t id_;
   Optional<TraceId> parent_id_;
+  bool sampled_;
   bool debug_;
   std::vector<Annotation> annotations_;
   std::vector<BinaryAnnotation> binary_annotations_;

--- a/zipkin/src/span_context.cc
+++ b/zipkin/src/span_context.cc
@@ -8,10 +8,10 @@ SpanContext::SpanContext(const Span &span) {
   trace_id_ = span.traceId();
   id_ = span.id();
   parent_id_ = span.isSetParentId() ? span.parentId() : 0;
+  flags_ = 0;
 
   if (span.isSampled()) {
     flags_ |= static_cast<unsigned char>(zipkin::sampled_flag);
-    flags_ |= static_cast<unsigned char>(zipkin::sampling_set_flag);
   }
 
   for (const Annotation &annotation : span.annotations()) {

--- a/zipkin/src/span_context.cc
+++ b/zipkin/src/span_context.cc
@@ -8,7 +8,7 @@ SpanContext::SpanContext(const Span &span) {
   trace_id_ = span.traceId();
   id_ = span.id();
   parent_id_ = span.isSetParentId() ? span.parentId() : 0;
-  
+
   if (span.isSampled()) {
     flags_ |= static_cast<unsigned char>(zipkin::sampled_flag);
     flags_ |= static_cast<unsigned char>(zipkin::sampling_set_flag);

--- a/zipkin/src/span_context.cc
+++ b/zipkin/src/span_context.cc
@@ -8,6 +8,11 @@ SpanContext::SpanContext(const Span &span) {
   trace_id_ = span.traceId();
   id_ = span.id();
   parent_id_ = span.isSetParentId() ? span.parentId() : 0;
+  
+  if (span.isSampled()) {
+    flags_ |= static_cast<unsigned char>(zipkin::sampled_flag);
+    flags_ |= static_cast<unsigned char>(zipkin::sampling_set_flag);
+  }
 
   for (const Annotation &annotation : span.annotations()) {
     if (annotation.value() == ZipkinCoreConstants::get().CLIENT_RECV) {

--- a/zipkin/src/zipkin_core_types.cc
+++ b/zipkin/src/zipkin_core_types.cc
@@ -185,7 +185,9 @@ const std::string Span::toJson() {
 
 void Span::finish() {
   if (auto t = tracer()) {
-    t->reportSpan(std::move(*this));
+    if (this->isSampled()) {
+      t->reportSpan(std::move(*this));
+    }
   }
 }
 

--- a/zipkin_opentracing/CMakeLists.txt
+++ b/zipkin_opentracing/CMakeLists.txt
@@ -8,7 +8,8 @@ set(ZIPKIN_OPENTRACING_SRCS src/utility.cc
                             src/propagation.cc
                             src/dynamic_load.cc
                             src/tracer_factory.cc
-                            src/opentracing.cc)
+                            src/opentracing.cc
+                            src/sampling.cc)
 
 if (BUILD_SHARED_LIBS)               
   add_library(zipkin_opentracing SHARED ${ZIPKIN_OPENTRACING_SRCS})

--- a/zipkin_opentracing/example/text_map_carrier.h
+++ b/zipkin_opentracing/example/text_map_carrier.h
@@ -5,10 +5,10 @@
 #include <string>
 #include <unordered_map>
 
-using opentracing::TextMapReader;
-using opentracing::TextMapWriter;
 using opentracing::expected;
 using opentracing::string_view;
+using opentracing::TextMapReader;
+using opentracing::TextMapWriter;
 
 class TextMapCarrier : public TextMapReader, public TextMapWriter {
 public:

--- a/zipkin_opentracing/include/zipkin/opentracing.h
+++ b/zipkin_opentracing/include/zipkin/opentracing.h
@@ -20,4 +20,5 @@ makeZipkinOtTracer(const ZipkinOtTracerOptions &options);
 std::shared_ptr<opentracing::Tracer>
 makeZipkinOtTracer(const ZipkinOtTracerOptions &options,
                    std::unique_ptr<Reporter> &&reporter);
+
 } // namespace zipkin

--- a/zipkin_opentracing/include/zipkin/opentracing.h
+++ b/zipkin_opentracing/include/zipkin/opentracing.h
@@ -8,6 +8,7 @@ struct ZipkinOtTracerOptions {
   uint32_t collector_port = 9411;
   SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD;
   size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE;
+  float sample_rate = 1.0f;
 
   std::string service_name;
   IpAddress service_address;

--- a/zipkin_opentracing/include/zipkin/opentracing.h
+++ b/zipkin_opentracing/include/zipkin/opentracing.h
@@ -8,7 +8,7 @@ struct ZipkinOtTracerOptions {
   uint32_t collector_port = 9411;
   SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD;
   size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE;
-  float sample_rate = 1.0f;
+  double sample_rate = 1.0;
 
   std::string service_name;
   IpAddress service_address;

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -391,8 +391,7 @@ makeZipkinOtTracer(const ZipkinOtTracerOptions &options,
   TracerPtr tracer{new Tracer{options.service_name, options.service_address}};
   tracer->setReporter(std::move(reporter));
   SamplerPtr sampler{new ProbabilisticSampler{options.sample_rate}};
-  return std::shared_ptr<ot::Tracer>{
-      new OtTracer{std::move(tracer), std::move(sampler)}};
+  return std::make_shared<OtTracer>(std::move(tracer), std::move(sampler));
 }
 
 std::shared_ptr<ot::Tracer>

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -295,10 +295,12 @@ public:
     if (pctx) {
       span->setSampled(pctx->isSampled());
     } else {
-      // ProbabilisticSampler s(0.5);
-      // if (s.ShouldSample()) {
-        span->setSampled(false);
-      // }
+      // TODO
+      // * pass sample rate from configuration
+      ProbabilisticSampler s(0.5);
+      if (s.ShouldSample()) {
+        span->setSampled(true);
+      }
     }
 
     Endpoint endpoint{tracer_->serviceName(), tracer_->address()};

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -298,9 +298,7 @@ public:
       // TODO
       // * pass sample rate from configuration
       ProbabilisticSampler s(0.5);
-      if (s.ShouldSample()) {
-        span->setSampled(true);
-      }
+      span->setSampled(s.ShouldSample());
     }
 
     Endpoint endpoint{tracer_->serviceName(), tracer_->address()};

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -341,8 +341,13 @@ public:
 private:
   TracerPtr tracer_;
   
-  bool hasParent(const ot::StartSpanOptions &options) const {
+  bool
+  hasParent(const ot::StartSpanOptions &options) const {
     for (auto ref : options.references) {
+      if (!ref.second) {
+        continue;
+      }
+      
       if (ref.first == ot::SpanReferenceType::ChildOfRef) {
         return true;
       }

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -106,6 +106,10 @@ public:
     return span_context_.isSampled();
   }
 
+  bool isValid() const {
+    return span_context_.id() != 0 && !span_context_.trace_id().empty();
+  }
+
 private:
   zipkin::SpanContext span_context_;
   mutable std::mutex baggage_mutex_;
@@ -293,10 +297,10 @@ public:
 
     auto parent = findSpanContext(options.references);
 
-    if (!parent) {
-      span->setSampled(sampler_->ShouldSample());
-    } else {
+    if (parent && parent->isValid()) {
       span->setSampled(parent->isSampled());
+    } else {
+      span->setSampled(sampler_->ShouldSample());
     }
     
     Endpoint endpoint{tracer_->serviceName(), tracer_->address()};

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -282,7 +282,7 @@ private:
 class OtTracer : public ot::Tracer,
                  public std::enable_shared_from_this<OtTracer> {
 public:
-  explicit OtTracer(TracerPtr &&tracer) : tracer_{std::move(tracer)}, sampler_{std::move(new ProbabilisticSampler(1.0))} {}
+  explicit OtTracer(TracerPtr &&tracer) : tracer_{std::move(tracer)}, sampler_{new ProbabilisticSampler(1.0)} {}
   explicit OtTracer(TracerPtr &&tracer, SamplerPtr &&sampler) : tracer_{std::move(tracer)}, sampler_{std::move(sampler)} {}
 
   std::unique_ptr<ot::Span>

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -1,6 +1,7 @@
 #include <zipkin/opentracing.h>
 #include <opentracing/util.h>
 
+#include "sampling.h"
 #include "propagation.h"
 #include "utility.h"
 #include <atomic>
@@ -291,13 +292,8 @@ public:
     //   different strategies
     // * we should be guarding this to set sampling only when its a
     //   root span
-    auto value = RandomUtil::generateId();
-    auto max = std::numeric_limits<uint64_t>::max();
-    long double sampling_rate = 0.5;
-    auto boundary = sampling_rate * max; // be false 50% of the time
-    auto samplingBoundary = static_cast<uint64_t>(boundary);
-
-    if (value > samplingBoundary) {
+    ProbabilisticSampler s(0.5);
+    if (s.ShouldSample()) {
       span->setSampled(true);
     }
 

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -278,6 +278,7 @@ private:
 class OtTracer : public ot::Tracer,
                  public std::enable_shared_from_this<OtTracer> {
 public:
+  explicit OtTracer(TracerPtr &&tracer) : tracer_{std::move(tracer)}, sampler_{std::move(new ProbabilisticSampler(1.0))} {}
   explicit OtTracer(TracerPtr &&tracer, SamplerPtr &&sampler) : tracer_{std::move(tracer)}, sampler_{std::move(sampler)} {}
 
   std::unique_ptr<ot::Span>

--- a/zipkin_opentracing/src/propagation.cc
+++ b/zipkin_opentracing/src/propagation.cc
@@ -138,7 +138,6 @@ extractSpanContext(const opentracing::TextMapReader &carrier,
           if (sampled) {
             flags |= sampled_flag;
           }
-          flags |= sampling_set_flag;
         } else if (keyCompare(key, zipkin_parent_span_id)) {
           parent_id = Hex::hexToTraceId(value);
           if (!parent_id.valid()) {

--- a/zipkin_opentracing/src/propagation.cc
+++ b/zipkin_opentracing/src/propagation.cc
@@ -135,7 +135,9 @@ extractSpanContext(const opentracing::TextMapReader &carrier,
           if (!parseBool(value, sampled)) {
             return ot::make_unexpected(ot::span_context_corrupted_error);
           }
-          flags |= sampled_flag;
+          if (sampled) {
+            flags |= sampled_flag;
+          }
         } else if (keyCompare(key, zipkin_parent_span_id)) {
           parent_id = Hex::hexToTraceId(value);
           if (!parent_id.valid()) {

--- a/zipkin_opentracing/src/propagation.cc
+++ b/zipkin_opentracing/src/propagation.cc
@@ -64,7 +64,7 @@ injectSpanContext(const opentracing::TextMapWriter &carrier,
   if (!result) {
     return result;
   }
-  result = carrier.Set(zipkin_sampled, "1");
+  result = carrier.Set(zipkin_sampled, span_context.isSampled() ? "1" : "0");
   if (!result) {
     return result;
   }
@@ -105,7 +105,7 @@ extractSpanContext(const opentracing::TextMapReader &carrier,
   TraceId trace_id;
   Optional<TraceId> parent_id;
   uint64_t span_id;
-  flags_t flags = 0;
+  flags_t flags = 0;  
   auto result = carrier.ForeachKey(
       [&](ot::string_view key, ot::string_view value) -> ot::expected<void> {
         if (keyCompare(key, zipkin_trace_id)) {

--- a/zipkin_opentracing/src/propagation.cc
+++ b/zipkin_opentracing/src/propagation.cc
@@ -105,7 +105,7 @@ extractSpanContext(const opentracing::TextMapReader &carrier,
   TraceId trace_id;
   Optional<TraceId> parent_id;
   uint64_t span_id;
-  flags_t flags = 0;  
+  flags_t flags = 0;
   auto result = carrier.ForeachKey(
       [&](ot::string_view key, ot::string_view value) -> ot::expected<void> {
         if (keyCompare(key, zipkin_trace_id)) {

--- a/zipkin_opentracing/src/propagation.cc
+++ b/zipkin_opentracing/src/propagation.cc
@@ -138,6 +138,7 @@ extractSpanContext(const opentracing::TextMapReader &carrier,
           if (sampled) {
             flags |= sampled_flag;
           }
+          flags |= sampling_set_flag;
         } else if (keyCompare(key, zipkin_parent_span_id)) {
           parent_id = Hex::hexToTraceId(value);
           if (!parent_id.valid()) {

--- a/zipkin_opentracing/src/sampling.cc
+++ b/zipkin_opentracing/src/sampling.cc
@@ -1,0 +1,13 @@
+#include "sampling.h"
+#include <random>
+
+namespace zipkin {
+  bool
+  ProbabilisticSampler::ShouldSample() {
+    std::random_device device;
+    std::mt19937 gen(device());
+    std::bernoulli_distribution dist(sample_rate_);
+    
+    return dist(gen);
+  }
+} // namespace zipkin

--- a/zipkin_opentracing/src/sampling.cc
+++ b/zipkin_opentracing/src/sampling.cc
@@ -1,4 +1,5 @@
 #include "sampling.h"
+#include <random>
 
 namespace zipkin {
   bool

--- a/zipkin_opentracing/src/sampling.cc
+++ b/zipkin_opentracing/src/sampling.cc
@@ -1,13 +1,10 @@
 #include "sampling.h"
-#include <random>
 
 namespace zipkin {
   bool
   ProbabilisticSampler::ShouldSample() {
-    std::random_device device;
-    std::mt19937 gen(device());
+    static thread_local std::mt19937 rng(std::random_device{}());
     std::bernoulli_distribution dist(sample_rate_);
-    
-    return dist(gen);
+    return dist(rng);
   }
 } // namespace zipkin

--- a/zipkin_opentracing/src/sampling.cc
+++ b/zipkin_opentracing/src/sampling.cc
@@ -2,10 +2,9 @@
 #include <random>
 
 namespace zipkin {
-  bool
-  ProbabilisticSampler::ShouldSample() {
-    static thread_local std::mt19937 rng(std::random_device{}());
-    std::bernoulli_distribution dist(sample_rate_);
-    return dist(rng);
-  }
+bool ProbabilisticSampler::ShouldSample() {
+  static thread_local std::mt19937 rng(std::random_device{}());
+  std::bernoulli_distribution dist(sample_rate_);
+  return dist(rng);
+}
 } // namespace zipkin

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <memory>
-#include <random>
 
 namespace zipkin {
   class Sampler {

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -11,7 +11,7 @@ public:
 
 class ProbabilisticSampler : public Sampler {
 public:
-  ProbabilisticSampler(double sample_rate)
+  explicit ProbabilisticSampler(double sample_rate)
       : sample_rate_(std::max(0.0, std::min(sample_rate, 1.0))){};
   bool ShouldSample() override;
 

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <algorithm>
 
 namespace zipkin {
   class Sampler {
@@ -10,7 +11,7 @@ namespace zipkin {
 
   class ProbabilisticSampler : public Sampler {
     public:
-      ProbabilisticSampler(double sample_rate) : sample_rate_(sample_rate) {};
+      ProbabilisticSampler(double sample_rate) : sample_rate_(std::max(0.0, std::min(sample_rate, 1.0))) {};
       bool ShouldSample() override;
 
     private:

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,22 +1,23 @@
 #pragma once
-#include <memory>
 #include <algorithm>
+#include <memory>
 
 namespace zipkin {
-  class Sampler {
-    public:
-      virtual ~Sampler() = default;
-      virtual bool ShouldSample() = 0;
-  };
+class Sampler {
+public:
+  virtual ~Sampler() = default;
+  virtual bool ShouldSample() = 0;
+};
 
-  class ProbabilisticSampler : public Sampler {
-    public:
-      ProbabilisticSampler(double sample_rate) : sample_rate_(std::max(0.0, std::min(sample_rate, 1.0))) {};
-      bool ShouldSample() override;
+class ProbabilisticSampler : public Sampler {
+public:
+  ProbabilisticSampler(double sample_rate)
+      : sample_rate_(std::max(0.0, std::min(sample_rate, 1.0))){};
+  bool ShouldSample() override;
 
-    private:
-      double sample_rate_;
-  };
+private:
+  double sample_rate_;
+};
 
-  typedef std::unique_ptr<Sampler> SamplerPtr;
+typedef std::unique_ptr<Sampler> SamplerPtr;
 } // namespace zipkin

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <random>
 
 namespace zipkin {
   class Sampler {

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 
 namespace zipkin {
   class Sampler {
@@ -15,4 +16,6 @@ namespace zipkin {
     private:
       double sample_rate_;
   };
+
+  typedef std::unique_ptr<Sampler> SamplerPtr;
 } // namespace zipkin

--- a/zipkin_opentracing/src/sampling.h
+++ b/zipkin_opentracing/src/sampling.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace zipkin {
+  class Sampler {
+    public:
+      virtual ~Sampler() = default;
+      virtual bool ShouldSample() = 0;
+  };
+
+  class ProbabilisticSampler : public Sampler {
+    public:
+      ProbabilisticSampler(double sample_rate) : sample_rate_(sample_rate) {};
+      bool ShouldSample() override;
+
+    private:
+      double sample_rate_;
+  };
+} // namespace zipkin

--- a/zipkin_opentracing/src/tracer_factory.cc
+++ b/zipkin_opentracing/src/tracer_factory.cc
@@ -41,7 +41,7 @@ const char *const configuration_schema = R"(
     "sample_rate": {
       "type": "float",
       "minimum": 0.0,
-      "maxiumum": 1.0,
+      "maxiumum": 1.0
     }
   }
 }
@@ -97,7 +97,7 @@ OtTracerFactory::MakeTracer(const char *configuration,
     options.max_buffered_spans = document["max_buffered_spans"].GetInt();
   }
   if (document.HasMember("sample_rate")) {
-    options.sample_rate = document["sample_rate"].GetFloat();
+    options.sample_rate = document["sample_rate"].GetDouble();
   }
   return makeZipkinOtTracer(options);
 } catch (const std::bad_alloc &) {

--- a/zipkin_opentracing/src/tracer_factory.cc
+++ b/zipkin_opentracing/src/tracer_factory.cc
@@ -37,6 +37,11 @@ const char *const configuration_schema = R"(
       "description":
         "The maximum number of spans to buffer before sending them to the collector",
       "minimum": 1
+    },
+    "sample_rate": {
+      "type": "float",
+      "minimum": 0.0,
+      "maxiumum": 1.0,
     }
   }
 }
@@ -90,6 +95,9 @@ OtTracerFactory::MakeTracer(const char *configuration,
   }
   if (document.HasMember("max_buffered_spans")) {
     options.max_buffered_spans = document["max_buffered_spans"].GetInt();
+  }
+  if (document.HasMember("sample_rate")) {
+    options.sample_rate = document["sample_rate"].GetFloat();
   }
   return makeZipkinOtTracer(options);
 } catch (const std::bad_alloc &) {

--- a/zipkin_opentracing/test/ot_tracer_test.cc
+++ b/zipkin_opentracing/test/ot_tracer_test.cc
@@ -67,8 +67,7 @@ TEST_CASE("ot_tracer") {
     CHECK(span_a);
     span_a->Finish();
 
-    auto spans = r->spans();
-    CHECK(spans.at(0).isSampled() == false);
+    CHECK(r->spans().empty());
   }
 
   SECTION("Propagates sampling decision to child span") {
@@ -89,8 +88,8 @@ TEST_CASE("ot_tracer") {
     CHECK(span_b);
     span_b->Finish();
 
-    CHECK(r1->spans().at(0).isSampled() == false);
-    CHECK(r2->spans().at(0).isSampled() == false);
+    CHECK(r1->spans().empty());
+    CHECK(r2->spans().empty());
   }
 
   SECTION("You can set a single child-of reference when starting a span.") {

--- a/zipkin_opentracing/test/ot_tracer_test.cc
+++ b/zipkin_opentracing/test/ot_tracer_test.cc
@@ -1,9 +1,9 @@
+#include "../src/sampling.h"
 #include "../src/utility.h"
 #include "in_memory_reporter.h"
 #include <algorithm>
 #include <opentracing/noop.h>
 #include <zipkin/opentracing.h>
-#include "../src/sampling.h"
 
 #define CATCH_CONFIG_MAIN
 #include <zipkin/catch/catch.hpp>
@@ -74,17 +74,20 @@ TEST_CASE("ot_tracer") {
     ZipkinOtTracerOptions no_sampling;
     no_sampling.sample_rate = 0.0;
     auto r1 = new InMemoryReporter();
-    auto no_sampling_tracer = makeZipkinOtTracer(no_sampling, std::unique_ptr<Reporter>(r1));
+    auto no_sampling_tracer =
+        makeZipkinOtTracer(no_sampling, std::unique_ptr<Reporter>(r1));
 
     ZipkinOtTracerOptions always_sample;
     always_sample.sample_rate = 1.0;
     auto r2 = new InMemoryReporter();
-    auto sampling_tracer = makeZipkinOtTracer(always_sample, std::unique_ptr<Reporter>(r2));
+    auto sampling_tracer =
+        makeZipkinOtTracer(always_sample, std::unique_ptr<Reporter>(r2));
 
     auto span_a = no_sampling_tracer->StartSpan("a");
     CHECK(span_a);
     span_a->Finish();
-    auto span_b = sampling_tracer->StartSpan("b", {ChildOf(&span_a->context())});
+    auto span_b =
+        sampling_tracer->StartSpan("b", {ChildOf(&span_a->context())});
     CHECK(span_b);
     span_b->Finish();
 


### PR DESCRIPTION
The work in this PR adds a basic probabilistic sampler. Sampling decisions are propagated between contexts and only sampled spans are reported.

`ZipkinOtTracerOptions` defaults a `sample_rate` to `1.0` (always sample) but can be changed between 0 and 1.