### PR TITLE
Add curl timeout

### DIFF
--- a/zipkin/include/zipkin/tracer.h
+++ b/zipkin/include/zipkin/tracer.h
@@ -9,7 +9,7 @@ namespace zipkin {
 const SteadyClock::duration DEFAULT_REPORTING_PERIOD =
     std::chrono::milliseconds{500};
 const size_t DEFAULT_SPAN_BUFFER_SIZE = 1000;
-const long DEFAULT_TRANSPORT_TIMEOUT = 0;
+const std::chrono::milliseconds DEFAULT_TRANSPORT_TIMEOUT = std::chrono::milliseconds{0};
 
 /**
  * Abstract class that delegates to users of the Tracer class the responsibility
@@ -56,7 +56,7 @@ typedef std::unique_ptr<Reporter> ReporterPtr;
  */
 ReporterPtr makeHttpReporter(
     const char *collector_host, uint32_t collector_port,
-    long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT,
+    std::chrono::milliseconds collector_timeout = DEFAULT_TRANSPORT_TIMEOUT,
     SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD,
     size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE);
 

--- a/zipkin/include/zipkin/tracer.h
+++ b/zipkin/include/zipkin/tracer.h
@@ -9,6 +9,7 @@ namespace zipkin {
 const SteadyClock::duration DEFAULT_REPORTING_PERIOD =
     std::chrono::milliseconds{500};
 const size_t DEFAULT_SPAN_BUFFER_SIZE = 1000;
+const long DEFAULT_TRANSPORT_TIMEOUT = 0;
 
 /**
  * Abstract class that delegates to users of the Tracer class the responsibility
@@ -55,6 +56,7 @@ typedef std::unique_ptr<Reporter> ReporterPtr;
  */
 ReporterPtr makeHttpReporter(
     const char *collector_host, uint32_t collector_port,
+    long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT,
     SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD,
     size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE);
 

--- a/zipkin/src/zipkin_http_transporter.cc
+++ b/zipkin/src/zipkin_http_transporter.cc
@@ -14,7 +14,8 @@ static std::string getUrl(const char *collector_host, uint32_t collector_port) {
 }
 
 ZipkinHttpTransporter::ZipkinHttpTransporter(const char *collector_host,
-                                             uint32_t collector_port) {
+                                             uint32_t collector_port,
+                                             long collector_timeout) {
   auto rcode = curl_easy_setopt(handle_, CURLOPT_URL,
                                 getUrl(collector_host, collector_port).c_str());
   if (rcode != CURLE_OK) {
@@ -29,6 +30,11 @@ ZipkinHttpTransporter::ZipkinHttpTransporter(const char *collector_host,
   }
 
   rcode = curl_easy_setopt(handle_, CURLOPT_ERRORBUFFER, error_buffer_);
+  if (rcode != CURLE_OK) {
+    throw CurlError{rcode};
+  }
+
+  rcode = curl_easy_setopt(handle_, CURLOPT_TIMEOUT_MS, collector_timeout);
   if (rcode != CURLE_OK) {
     throw CurlError{rcode};
   }
@@ -53,10 +59,11 @@ void ZipkinHttpTransporter::transportSpans(SpanBuffer &spans) try {
 
 ReporterPtr makeHttpReporter(const char *collector_host,
                              uint32_t collector_port,
+                             long collector_timeout,
                              SteadyClock::duration reporting_period,
                              size_t max_buffered_spans) try {
   std::unique_ptr<Transporter> transporter{
-      new ZipkinHttpTransporter{collector_host, collector_port}};
+      new ZipkinHttpTransporter{collector_host, collector_port, collector_timeout}};
   std::unique_ptr<Reporter> reporter{new ReporterImpl{
       std::move(transporter), reporting_period, max_buffered_spans}};
   return reporter;

--- a/zipkin/src/zipkin_http_transporter.cc
+++ b/zipkin/src/zipkin_http_transporter.cc
@@ -15,7 +15,7 @@ static std::string getUrl(const char *collector_host, uint32_t collector_port) {
 
 ZipkinHttpTransporter::ZipkinHttpTransporter(const char *collector_host,
                                              uint32_t collector_port,
-                                             long collector_timeout) {
+                                             std::chrono::milliseconds collector_timeout) {
   auto rcode = curl_easy_setopt(handle_, CURLOPT_URL,
                                 getUrl(collector_host, collector_port).c_str());
   if (rcode != CURLE_OK) {
@@ -34,7 +34,7 @@ ZipkinHttpTransporter::ZipkinHttpTransporter(const char *collector_host,
     throw CurlError{rcode};
   }
 
-  rcode = curl_easy_setopt(handle_, CURLOPT_TIMEOUT_MS, collector_timeout);
+  rcode = curl_easy_setopt(handle_, CURLOPT_TIMEOUT_MS, collector_timeout.count());
   if (rcode != CURLE_OK) {
     throw CurlError{rcode};
   }
@@ -59,7 +59,7 @@ void ZipkinHttpTransporter::transportSpans(SpanBuffer &spans) try {
 
 ReporterPtr makeHttpReporter(const char *collector_host,
                              uint32_t collector_port,
-                             long collector_timeout,
+                             std::chrono::milliseconds collector_timeout,
                              SteadyClock::duration reporting_period,
                              size_t max_buffered_spans) try {
   std::unique_ptr<Transporter> transporter{

--- a/zipkin/src/zipkin_http_transporter.h
+++ b/zipkin/src/zipkin_http_transporter.h
@@ -90,7 +90,8 @@ public:
    *
    * Throws CurlError if the handle can't be initialized.
    */
-  ZipkinHttpTransporter(const char *collector_host, uint32_t collector_port, long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT);
+  ZipkinHttpTransporter(const char *collector_host, uint32_t collector_port,
+          std::chrono::milliseconds collector_timeout = DEFAULT_TRANSPORT_TIMEOUT);
 
   /**
    * Destructor.

--- a/zipkin/src/zipkin_http_transporter.h
+++ b/zipkin/src/zipkin_http_transporter.h
@@ -85,11 +85,12 @@ public:
    *
    * @param collector_host The host to use when sending spans to the Zipkin
    * service.
-   * @param port The port to use when sending spans to the Zipkin service.
+   * @param collector_port The port to use when sending spans to the Zipkin service.
+   * @param collector_timeout Timeout for http requests
    *
    * Throws CurlError if the handle can't be initialized.
    */
-  ZipkinHttpTransporter(const char *collector_host, uint32_t collector_port);
+  ZipkinHttpTransporter(const char *collector_host, uint32_t collector_port, long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT);
 
   /**
    * Destructor.

--- a/zipkin_opentracing/include/zipkin/opentracing.h
+++ b/zipkin_opentracing/include/zipkin/opentracing.h
@@ -6,6 +6,7 @@ namespace zipkin {
 struct ZipkinOtTracerOptions {
   std::string collector_host = "localhost";
   uint32_t collector_port = 9411;
+  long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT;
   SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD;
   size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE;
   double sample_rate = 1.0;

--- a/zipkin_opentracing/include/zipkin/opentracing.h
+++ b/zipkin_opentracing/include/zipkin/opentracing.h
@@ -6,7 +6,7 @@ namespace zipkin {
 struct ZipkinOtTracerOptions {
   std::string collector_host = "localhost";
   uint32_t collector_port = 9411;
-  long collector_timeout = DEFAULT_TRANSPORT_TIMEOUT;
+  std::chrono::milliseconds collector_timeout = DEFAULT_TRANSPORT_TIMEOUT;
   SteadyClock::duration reporting_period = DEFAULT_REPORTING_PERIOD;
   size_t max_buffered_spans = DEFAULT_SPAN_BUFFER_SIZE;
   double sample_rate = 1.0;

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -398,7 +398,8 @@ std::shared_ptr<ot::Tracer>
 makeZipkinOtTracer(const ZipkinOtTracerOptions &options) {
   auto reporter =
       makeHttpReporter(options.collector_host.c_str(), options.collector_port,
-                       options.reporting_period, options.max_buffered_spans);
+                       options.collector_timeout, options.reporting_period,
+                       options.max_buffered_spans);
   return makeZipkinOtTracer(options, std::move(reporter));
 }
 } // namespace zipkin

--- a/zipkin_opentracing/src/tracer_factory.cc
+++ b/zipkin_opentracing/src/tracer_factory.cc
@@ -53,7 +53,8 @@ OtTracerFactory::MakeTracer(const char *configuration,
     options.collector_port = document["collector_port"].GetInt();
   }
   if (document.HasMember("collector_timeout")) {
-    options.collector_timeout = document["collector_timeout"].GetInt();
+    options.collector_timeout =
+            std::chrono::milliseconds{document["collector_timeout"].GetInt()};
   }
   if (document.HasMember("reporting_period")) {
     options.reporting_period =

--- a/zipkin_opentracing/src/tracer_factory.cc
+++ b/zipkin_opentracing/src/tracer_factory.cc
@@ -52,6 +52,9 @@ OtTracerFactory::MakeTracer(const char *configuration,
   if (document.HasMember("collector_port")) {
     options.collector_port = document["collector_port"].GetInt();
   }
+  if (document.HasMember("collector_timeout")) {
+    options.collector_timeout = document["collector_timeout"].GetInt();
+  }
   if (document.HasMember("reporting_period")) {
     options.reporting_period =
         std::chrono::microseconds{document["reporting_period"].GetInt()};


### PR DESCRIPTION
HTTP Transport can hang on exit due to undefined Curl timeout. This PR 
fixes this issue, see https://github.com/rnburn/zipkin-cpp-opentracing/issues/30.