### PR TITLE
fix compile problem: Clone method of abstract class SpanContext is no implemented

### DIFF
--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -108,6 +108,10 @@ public:
     return span_context_.id() != 0 && !span_context_.trace_id().empty();
   }
 
+  std::unique_ptr<SpanContext> Clone() const noexcept
+  {
+    return nullptr;
+  }
 private:
   zipkin::SpanContext span_context_;
   mutable std::mutex baggage_mutex_;


### PR DESCRIPTION
fix compile problem: Clone method of abstract class SpanContext is no implemented