### PR TITLE
Fix compilation errors

### DIFF
--- a/zipkin/include/zipkin/ip_address.h
+++ b/zipkin/include/zipkin/ip_address.h
@@ -24,7 +24,7 @@ public:
 
 private:
   IpVersion version_;
-  uint32_t port_;
   std::string friendly_address_;
+  uint32_t port_;
 };
 } // namespace zipkin

--- a/zipkin_opentracing/test/ot_tracer_test.cc
+++ b/zipkin_opentracing/test/ot_tracer_test.cc
@@ -2,6 +2,7 @@
 #include "../src/utility.h"
 #include "in_memory_reporter.h"
 #include <algorithm>
+#include <stdexcept>
 #include <opentracing/noop.h>
 #include <zipkin/opentracing.h>
 
@@ -28,6 +29,8 @@ static bool hasTag(const Span &span, ot::string_view key, ot::Value value) {
           return tag_annotation.valueInt64() == annotation.valueInt64();
         case DOUBLE:
           return tag_annotation.valueDouble() == annotation.valueDouble();
+        default:
+          throw std::runtime_error("Unhandled annotation type");
         }
       });
 }


### PR DESCRIPTION
Compilation emits warnings (in -Wall mode):
```
INFO: From Compiling zipkin/src/ip_address.cc:
In file included from zipkin/src/ip_address.cc:8:0:
bazel-out/k8-fastbuild/bin/_virtual_includes/zipkin/zipkin/ip_address.h: In constructor 'zipkin::IpAddress::IpAddress(zipkin::IpVersion, const string&, uint32_t)':
bazel-out/k8-fastbuild/bin/_virtual_includes/zipkin/zipkin/ip_address.h:28:15: warning: 'zipkin::IpAddress::friendly_address_' will be initialized after [-Wreorder]
   std::string friendly_address_;
               ^~~~~~~~~~~~~~~~~
bazel-out/k8-fastbuild/bin/_virtual_includes/zipkin/zipkin/ip_address.h:27:12: warning:   'uint32_t zipkin::IpAddress::port_' [-Wreorder]
   uint32_t port_;
            ^~~~~

[ 93%] Building CXX object zipkin_opentracing/test/CMakeFiles/ot_tracer_test.dir/ot_tracer_test.cc.o
/opt/orabuild/rpmbuild/SOURCES/ZIPKIN-CPP-OPENTRACING/zipkin-cpp-opentracing_new.git/zipkin_opentracing/test/ot_tracer_test.cc: In lambda function:
/opt/orabuild/rpmbuild/SOURCES/ZIPKIN-CPP-OPENTRACING/zipkin-cpp-opentracing_new.git/zipkin_opentracing/test/ot_tracer_test.cc:32:7: warning: control reaches end of non-void function [-Wreturn-type]
       });
```