### PR TITLE
128 bit trace ids

### DIFF
--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "io_opentracing_cpp",
     remote = "https://github.com/opentracing/opentracing-cpp",
-    commit = "ac50154a7713877f877981c33c3375003b6ebfe1",
+    commit = "597b0fa9507c854877b3efa9f4f20293a9e1ed30",
 )
 
 new_local_repository(

--- a/ci/build_plugin.sh
+++ b/ci/build_plugin.sh
@@ -9,7 +9,7 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 git \
                 ca-certificates
 
-export OPENTRACING_VERSION=1.5.0
+export OPENTRACING_VERSION=1.6.0
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64"

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -11,7 +11,7 @@ apt-get install --no-install-recommends --no-install-suggests -y \
 
 # Build OpenTracing
 cd /
-export OPENTRACING_VERSION=1.5.0
+export OPENTRACING_VERSION=1.6.0
 git clone -b v$OPENTRACING_VERSION https://github.com/opentracing/opentracing-cpp.git
 cd opentracing-cpp
 mkdir .build && cd .build

--- a/zipkin/include/zipkin/span_context.h
+++ b/zipkin/include/zipkin/span_context.h
@@ -24,6 +24,7 @@ namespace zipkin {
  */
 struct AnnotationSet {
   AnnotationSet() : cs_(false), cr_(false), ss_(false), sr_(false) {}
+  AnnotationSet(const AnnotationSet &set) : cs_{set.cs_}, cr_{set.cr_}, ss_{set.ss_}, sr_{set.sr_} {}
   bool cs_ : 1;
   bool cr_ : 1;
   bool ss_ : 1;
@@ -57,6 +58,15 @@ public:
               const Optional<TraceId> &parent_id, flags_t flags)
       : trace_id_{trace_id}, id_{id}, parent_id_{parent_id}, flags_{flags},
         is_initialized_{true} {}
+
+  /**
+   * Copy constructor that creates a context object from the given SpanContext
+   * instance.
+   */
+  SpanContext(const SpanContext &span)
+      : trace_id_{span.trace_id_}, id_{span.id_}, parent_id_{span.parent_id_},
+        annotation_values_{span.annotation_values_}, flags_{span.flags_},
+        is_initialized_{span.is_initialized_} {}
 
   bool isSampled() const { return flags_ & zipkin::sampled_flag; }
 

--- a/zipkin/include/zipkin/trace_id.h
+++ b/zipkin/include/zipkin/trace_id.h
@@ -9,7 +9,7 @@ public:
 
   TraceId(uint64_t high, uint64_t low) : high_{high}, low_{low} {}
 
-  TraceId(uint64_t low) : TraceId{0, low} {}
+  explicit TraceId(uint64_t low) : TraceId{0, low} {}
 
   uint64_t high() const { return high_; }
 

--- a/zipkin/src/span_context.cc
+++ b/zipkin/src/span_context.cc
@@ -7,7 +7,7 @@ namespace zipkin {
 SpanContext::SpanContext(const Span &span) {
   trace_id_ = span.traceId();
   id_ = span.id();
-  parent_id_ = span.isSetParentId() ? span.parentId() : 0;
+  parent_id_ = span.isSetParentId() ? span.parentId() : TraceId(0);
   flags_ = 0;
 
   if (span.isSampled()) {

--- a/zipkin/src/tracer.cc
+++ b/zipkin/src/tracer.cc
@@ -13,8 +13,8 @@ SpanPtr Tracer::startSpan(const std::string &span_name, SystemTime timestamp) {
   // Create an all-new span, with no parent id
   SpanPtr span_ptr(new Span());
   span_ptr->setName(span_name);
-  uint64_t random_number = RandomUtil::generateId();
-  span_ptr->setId(random_number);
+  TraceId random_number(RandomUtil::generateId(), RandomUtil::generateId());
+  span_ptr->setId(random_number.low());
   span_ptr->setTraceId(random_number);
   int64_t start_time_micro =
       std::chrono::duration_cast<std::chrono::microseconds>(
@@ -56,7 +56,7 @@ SpanPtr Tracer::startSpan(const std::string &span_name, SystemTime timestamp,
     span_ptr->setName(span_name);
 
     // Set the parent id to the id of the previous span
-    span_ptr->setParentId(previous_context.id());
+    span_ptr->setParentId(TraceId(previous_context.id()));
 
     // Set the CS annotation value
     annotation.setValue(ZipkinCoreConstants::get().CLIENT_SEND);

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -157,9 +157,9 @@ public:
     span_->setId(RandomUtil::generateId());
     if (parent_span_context) {
       span_->setTraceId(parent_span_context->span_context_.trace_id());
-      span_->setParentId(parent_span_context->span_context_.id());
+      span_->setParentId(TraceId(parent_span_context->span_context_.id()));
     } else {
-      span_->setTraceId(RandomUtil::generateId());
+      span_->setTraceId(TraceId(RandomUtil::generateId(), RandomUtil::generateId()));
     }
 
     // Set timestamp.

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -50,6 +50,9 @@ class OtSpanContext : public ot::SpanContext {
 public:
   OtSpanContext() = default;
 
+  OtSpanContext(const OtSpanContext &span)
+      : span_context_{span.span_context_}, baggage_{span.baggage_} {}
+
   explicit OtSpanContext(zipkin::SpanContext &&span_context)
       : span_context_{std::move(span_context)} {}
 
@@ -67,6 +70,20 @@ public:
     span_context_ = std::move(other.span_context_);
     baggage_ = std::move(other.baggage_);
     return *this;
+  }
+
+  std::unique_ptr<SpanContext> Clone() const noexcept override try {
+    return std::unique_ptr<SpanContext> (new OtSpanContext(*this));
+  } catch (...) {
+    return nullptr;
+  }
+
+  std::string ToTraceID() const noexcept override {
+    return span_context_.traceIdAsHexString();
+  }
+
+  std::string ToSpanID() const noexcept override {
+    return span_context_.idAsHexString();
   }
 
   void ForeachBaggageItem(
@@ -257,6 +274,14 @@ public:
 
   void Log(std::initializer_list<std::pair<string_view, Value>>
                fields) noexcept override {}
+
+  void Log(
+    SystemTime timestamp,
+    std::initializer_list<std::pair<string_view, Value>> fields) noexcept override {}
+
+  void Log(
+    SystemTime timestamp,
+    const std::vector<std::pair<string_view, Value>>& fields) noexcept override {}
 
   const ot::SpanContext &context() const noexcept override {
     return span_context_;

--- a/zipkin_opentracing/test/ot_tracer_test.cc
+++ b/zipkin_opentracing/test/ot_tracer_test.cc
@@ -29,11 +29,12 @@ static bool hasTag(const Span &span, ot::string_view key, ot::Value value) {
         case DOUBLE:
           return tag_annotation.valueDouble() == annotation.valueDouble();
         }
+        return false;
       });
 }
 
 static bool IsChildOf(const zipkin::Span &a, const zipkin::Span &b) {
-  return a.isSetParentId() && a.parentId() == b.id() &&
+  return a.isSetParentId() && a.parentId().low() == b.id() &&
          a.traceId() == b.traceId();
 }
 

--- a/zipkin_opentracing/test/ot_tracer_test.cc
+++ b/zipkin_opentracing/test/ot_tracer_test.cc
@@ -37,6 +37,20 @@ static bool IsChildOf(const zipkin::Span &a, const zipkin::Span &b) {
          a.traceId() == b.traceId();
 }
 
+class TextMapCarrier : public ot::TextMapWriter {
+public:
+  TextMapCarrier(std::unordered_map<std::string, std::string> &text_map)
+      : text_map_(text_map) {}
+
+  ot::expected<void> Set(ot::string_view key, ot::string_view value) const override {
+    text_map_[key] = value;
+    return {};
+  }
+
+private:
+  std::unordered_map<std::string, std::string> &text_map_;
+};
+
 TEST_CASE("ot_tracer") {
   auto reporter = new InMemoryReporter();
   ZipkinOtTracerOptions options;
@@ -166,5 +180,59 @@ TEST_CASE("ot_tracer") {
     span->SetTag("abc", 123);
     span->Finish();
     CHECK(hasTag(reporter->top(), "abc", 123));
+  }
+
+  SECTION("Get SpanContext and check that it is valid after Finish") {
+    auto span = tracer->StartSpan("a");
+    CHECK(span);
+    span->SetTag("abc", 123);
+    auto &ctx = span->context();
+    span->Finish();
+    auto trace_id = ctx.ToTraceID();
+    CHECK(trace_id != "");
+    auto span_id = ctx.ToSpanID();
+    CHECK(span_id != "");
+  }
+
+  SECTION("Check SpanContext.Clone() preserves attributes") {
+    auto span = tracer->StartSpan("a");
+    CHECK(span);
+    span->SetTag("abc", 123);
+    span->SetBaggageItem("a", "1");
+    auto &ctx = span->context();
+    span->Finish();
+    auto ctx2 = ctx.Clone();
+
+    CHECK(ctx.ToTraceID() == ctx2->ToTraceID());
+    CHECK(ctx.ToSpanID() == ctx2->ToSpanID());
+
+    std::unordered_map<std::string, std::string> items;
+    ctx.ForeachBaggageItem(
+        [&items] (const std::string& key, const std::string& value) {
+            items[key] = value;
+            return true;
+        }
+    );
+
+    std::unordered_map<std::string, std::string> items2;
+    ctx2->ForeachBaggageItem(
+        [&items2] (const std::string& key, const std::string& value) {
+            items2[key] = value;
+            return true;
+        }
+    );
+    CHECK(items == items2);
+
+    // Cross-check: serialize span context to a carrier
+    // and compare low-level representation
+    items.clear();
+    items2.clear();
+
+    TextMapCarrier carrier{items};
+    tracer->Inject(ctx, carrier);
+    TextMapCarrier carrier2{items2};
+    tracer->Inject(*ctx2, carrier2);
+
+    CHECK(items == items2);
   }
 }


### PR DESCRIPTION
Closes #36 

To prevent accidental casts from uint64_t to `TraceId`s (since they're 128-bit nowadays), the 64-bit `TraceId` constructor is made explicit.