### PR TITLE
implementing virtual functions for compatibility

### DIFF
--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "io_opentracing_cpp",
     remote = "https://github.com/opentracing/opentracing-cpp",
-    commit = "ac50154a7713877f877981c33c3375003b6ebfe1",
+    commit = "4bb431f7728eaf383a07e86f9754a5b67575dab0",
 )
 
 new_local_repository(

--- a/ci/build_plugin.sh
+++ b/ci/build_plugin.sh
@@ -9,7 +9,7 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 git \
                 ca-certificates
 
-export OPENTRACING_VERSION=1.5.0
+export OPENTRACING_VERSION=1.6.0
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64"

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -11,7 +11,7 @@ apt-get install --no-install-recommends --no-install-suggests -y \
 
 # Build OpenTracing
 cd /
-export OPENTRACING_VERSION=1.5.0
+export OPENTRACING_VERSION=1.6.0
 git clone -b v$OPENTRACING_VERSION https://github.com/opentracing/opentracing-cpp.git
 cd opentracing-cpp
 mkdir .build && cd .build

--- a/zipkin_opentracing/src/opentracing.cc
+++ b/zipkin_opentracing/src/opentracing.cc
@@ -108,6 +108,11 @@ public:
     return span_context_.id() != 0 && !span_context_.trace_id().empty();
   }
 
+  std::unique_ptr<SpanContext> Clone() const noexcept
+  {
+    return nullptr;
+  }
+
 private:
   zipkin::SpanContext span_context_;
   mutable std::mutex baggage_mutex_;
@@ -256,6 +261,12 @@ public:
   }
 
   void Log(std::initializer_list<std::pair<string_view, Value>>
+               fields) noexcept override {}
+
+  void Log(SystemTime timestamp, std::initializer_list<std::pair<string_view, Value>>
+               fields) noexcept override {}
+
+  void Log(SystemTime timestamp, const std::vector<std::pair<string_view, Value>>&
                fields) noexcept override {}
 
   const ot::SpanContext &context() const noexcept override {


### PR DESCRIPTION
This is essentially a no-op, it just ensures that this library builds properly with opentracing-cpp v1.6.0.
- Virtual `Log` introduced: opentracing/opentracing-cpp#109
- Virtual `Clone` introduced: opentracing/opentracing-cpp#56

This was previously attempted in #34 but `Log` is needed as well. I'm hoping this can be done soon in order to upgrade tracing libraries used in kubernetes/ingress-nginx.